### PR TITLE
Check for nested comments and signal error

### DIFF
--- a/src/mlfe_scan.xrl
+++ b/src/mlfe_scan.xrl
@@ -143,7 +143,8 @@ _    : {token, {'_', TokenLine}}.
 --[.]*\n :
   Text = string:sub_string(TokenChars, 3),
   {token, {comment_line, TokenLine, Text}}.
-({-([^-]|(-+[^}]))*-})|(--.*) : {token, {comment_lines, TokenLine, TokenChars}}.
+({-([^-]|(-+[^}]))*-})|(--.*) :
+  validate_comment(TokenLine, string:substr(TokenChars, 3)).
 
 
 
@@ -152,3 +153,9 @@ Erlang code.
 -dialyzer({nowarn_function, yyrev/2}).
 
 -ignore_xref([format_error/1, string/2, token/2, token/3, tokens/2, tokens/3]).
+
+validate_comment(TokenLine, TokenChars) ->
+    case string:str(TokenChars, "{-") of
+        0 -> {token, {comment_lines, TokenLine, TokenChars}};
+        _ -> {error, {nested_comment, TokenChars}}
+    end.


### PR DESCRIPTION
Similar to [`lfe_scan`'s `block_comment/1`](https://github.com/rvirding/lfe/blob/1.1.1/src/lfe_scan.xrl#L234-L245), `validate_comment/2` will check for a nested comment and provide a sensible error instead of just exploding.

Thanks, @rvirding.